### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+web/* linguist-documentation


### PR DESCRIPTION
This allows github to accurately recognize that this is a Rust repo