### PR TITLE
Fix an error that all documents in the corpus could not be indexed using Bleve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: index
 
 corpus:
 	@echo "--- Downloading $(WIKI_SRC) ---"
-	@curl -# -L "$(WIKI_SRC)" | bunzip2 -c | python corpus_transform.py > $(CORPUS) 
+	@curl -# -L "$(WIKI_SRC)" | bunzip2 -c | python3 corpus_transform.py > $(CORPUS)
 
 clean:
 	@echo "--- Cleaning directories ---"

--- a/corpus_transform.py
+++ b/corpus_transform.py
@@ -8,9 +8,18 @@ def transform(text):
     return PTN.sub(" ", text.lower())
 
 for line in fileinput.input():
-    doc = json.loads(line)
+    doc = {}
+    try:
+        doc = json.loads(line)
+    except ValueError:
+        continue
+
+    if doc["url"] == "":
+        continue
+
     doc_transformed = {
         "id": doc["url"],
         "text": transform(doc["body"])
     }
-    print json.dumps(doc_transformed)
+
+    print(json.dumps(doc_transformed))


### PR DESCRIPTION
When indexing the corpus using Bleve, the following error has occurred:

```
document ID cannot be empty
```

Indexing stopped halfway due to empty `id`.
The following is the document of the error cause:

```
{"text": " tag or the document end in this dtd specification the behavior of the tag omission feature is specified for each element by the two characters following the element name the values can be or o for disabling and enabling the features the first character specifies the behavior of the start tag and the second the behavior of the end tag a valid document not using tag omission a valid document simplified by using tag omission ", "id": ""}
```

Modify `corpus_transform.py` to ignore documents with an empty `url`.
